### PR TITLE
Require qwery

### DIFF
--- a/component.json
+++ b/component.json
@@ -12,7 +12,8 @@
   },
   "development": {
     "fat/bean": "*",
-    "chaijs/chai": "*"
+    "chaijs/chai": "*",
+    "ded/qwery": "*"
   },
   "scripts": [
     "index.js"

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var classie = require('classie')
 var oneBtn = fs.readFileSync(__dirname + '/one_button.html', 'utf8')
 var twoBtn = fs.readFileSync(__dirname + '/two_button.html', 'utf8')
 var key = require('keymaster')
+var qwery = require('qwery')
 var animEvent = require('animevent')
 
 var Wagon = require('wagon')

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     ]
   },
   "devDependencies": {
+    "qwery": "^4.0.0",
     "bean": "^1.0.14",
     "browserify": "^4.2.0",
     "chai": "^1.9.1",


### PR DESCRIPTION
Right now the submit action of a dialog fails because it tries to use qwery which isn't required. I'm not sure if I did this right, though. Mind checking @jeromegn?
